### PR TITLE
fix: docker container not listening on all interfaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ WORKDIR /app
 # ENV PATH="/app/.venv/bin:/app/node_modules/.bin:$PATH"
 ENV PATH="/app/.venv/bin:/app/bun_global/bin:$PATH"
 ENV PYTHONPATH=/app
-ENV HOST=0.0.0.0
-ENV PORT=8000
+ENV SERVER__HOST=0.0.0.0
+ENV SERVER__PORT=8000
 
 EXPOSE ${PORT:-8000}
 


### PR DESCRIPTION
The environment variable in the Dockerfile needed to set SERVER__HOST to 0.0.0.0 to listen on all interfaces.

PORT was being set, but it wasn't making its way into the server, causing it to listen on only the loopback address by default.

This was preventing access from the docker host even if the port was exposed.