### PR TITLE
fix: Add tool_calls array to OpenAI chat completions response

### DIFF
--- a/ccproxy/llms/formatters/anthropic_to_openai/_helpers.py
+++ b/ccproxy/llms/formatters/anthropic_to_openai/_helpers.py
@@ -1,0 +1,44 @@
+"""Shared helpers for Anthropic to OpenAI formatting."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ccproxy.llms.models import openai as openai_models
+
+
+def serialize_tool_arguments(tool_input: Any) -> str:
+    if isinstance(tool_input, str):
+        return tool_input
+    try:
+        return json.dumps(tool_input, ensure_ascii=False)
+    except Exception:
+        return json.dumps({"arguments": str(tool_input)})
+
+
+def build_openai_tool_call(
+    *,
+    tool_id: str | None,
+    tool_name: str | None,
+    tool_input: Any,
+    arguments: Any = None,
+    fallback_index: int = 0,
+) -> openai_models.ToolCall:
+    args_str = (
+        arguments
+        if isinstance(arguments, str) and arguments
+        else serialize_tool_arguments(tool_input)
+    )
+    call_id = (
+        tool_id if isinstance(tool_id, str) and tool_id else f"call_{fallback_index}"
+    )
+    name = tool_name if isinstance(tool_name, str) and tool_name else "function"
+
+    return openai_models.ToolCall(
+        id=str(call_id),
+        function=openai_models.FunctionCall(
+            name=str(name),
+            arguments=str(args_str),
+        ),
+    )

--- a/tests/unit/llms/formatters/test_formatter_endpoint_samples.py
+++ b/tests/unit/llms/formatters/test_formatter_endpoint_samples.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -429,6 +430,7 @@ ANTHROPIC_CHAT_CASES = [
         {
             "expected_finish": "tool_calls",
             "text_snippet": "weather information",
+            "tool_names": {"get_weather", "calculate_distance"},
         },
     ),
 ]
@@ -451,6 +453,13 @@ def test_anthropic_message_to_openai_chat(
     content = choice.message.content or ""
     if isinstance(content, str) and expect.get("text_snippet"):
         assert expect["text_snippet"] in content
+
+    if expect.get("tool_names"):
+        tool_calls = choice.message.tool_calls or []
+        tool_names = {tool_call.function.name for tool_call in tool_calls}
+        assert tool_names == expect["tool_names"]
+        for tool_call in tool_calls:
+            assert json.loads(tool_call.function.arguments)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

This PR fixes a bug where the `convert__anthropic_message_to_openai_chat__response` function was not converting Anthropic `tool_use` blocks to OpenAI `tool_calls` format in chat completion responses.

**The Problem:**
When Claude returns a tool use response, the converter correctly set `finish_reason: "tool_calls"` but the actual `tool_calls` array was missing from the response message:

```json
{
  "choices": [{
    "finish_reason": "tool_calls",
    "message": {
      "role": "assistant",
      "content": ""
      // MISSING: "tool_calls": [...]
    }
  }]
}
```

**The Fix:**
This PR adds handling for `tool_use` blocks in the response converter, converting them to the OpenAI `tool_calls` format:

```json
{
  "choices": [{
    "finish_reason": "tool_calls", 
    "message": {
      "role": "assistant",
      "content": null,
      "tool_calls": [{
        "id": "toolu_xxx",
        "type": "function",
        "function": {
          "name": "get_gmail",
          "arguments": "{}"
        }
      }]
    }
  }]
}
```

## Use Case

This fix is required for **n8n AI Agent workflows** and other OpenAI-compatible clients that rely on the `tool_calls` array to execute function calls. Without this fix, the AI Agent sees the tools are available but Claude's tool call requests are lost in translation.

## Changes

- Added handling for `tool_use` blocks in `convert__anthropic_message_to_openai_chat__response`
- Converts Anthropic tool_use format (`id`, `name`, `input`) to OpenAI tool_calls format (`id`, `type`, `function.name`, `function.arguments`)
- Sets `content` to `None` when there's no text content (per OpenAI spec)
- Added `json` import for serializing tool arguments

## Test plan

- [x] Tested with CCProxy-API v0.2.0 on Docker
- [x] Verified tool_calls array is now present in responses
- [x] Tested with n8n AI Agent workflow - tools now execute correctly