### PR TITLE
Reasoning fixes

### DIFF
--- a/ccproxy/llms/formatters/anthropic_to_openai/responses.py
+++ b/ccproxy/llms/formatters/anthropic_to_openai/responses.py
@@ -44,13 +44,10 @@ def convert__anthropic_message_to_openai_responses__response(
             text_parts.append(getattr(block, "text", ""))
         elif block_type == "thinking":
             thinking = getattr(block, "thinking", None) or ""
-            signature = getattr(block, "signature", None)
-            sig_attr = (
-                f' signature="{signature}"'
-                if isinstance(signature, str) and signature
-                else ""
-            )
-            text_parts.append(f"<thinking{sig_attr}>{thinking}</thinking>")
+            text_parts.append(f"<think>{thinking}</think>")
+        elif block_type == "redacted_thinking":
+            # Skip redacted thinking blocks
+            continue
         elif block_type == "tool_use":
             tool_contents.append(
                 {
@@ -113,14 +110,11 @@ def convert__anthropic_message_to_openai_chat__response(
                 parts.append(text)
         elif btype == "thinking":
             thinking = getattr(block, "thinking", None)
-            signature = getattr(block, "signature", None)
             if isinstance(thinking, str):
-                sig_attr = (
-                    f' signature="{signature}"'
-                    if isinstance(signature, str) and signature
-                    else ""
-                )
-                parts.append(f"<thinking{sig_attr}>{thinking}</thinking>")
+                parts.append(f"<think>{thinking}</think>")
+        # Skip redacted_thinking blocks
+        elif btype == "redacted_thinking":
+            continue
         elif btype == "tool_use":
             tool_calls.append(
                 build_openai_tool_call(

--- a/ccproxy/llms/models/anthropic.py
+++ b/ccproxy/llms/models/anthropic.py
@@ -219,7 +219,13 @@ class RedactedThinkingBlock(ContentBlockBase):
 
 
 RequestContentBlock = Annotated[
-    TextBlock | ImageBlock | ToolUseBlock | ToolResultBlock, Field(discriminator="type")
+    TextBlock
+    | ImageBlock
+    | ToolUseBlock
+    | ToolResultBlock
+    | ThinkingBlock
+    | RedactedThinkingBlock,
+    Field(discriminator="type"),
 ]
 
 ResponseContentBlock = Annotated[


### PR DESCRIPTION
This PR fixes several issues around handling thinking blocks:

### Anthropic API: Accept thinking blocks in requests

Clients that try to pass thinking blocks back in consecutive requests were getting an error:

```
body -> messages -> 1 -> content -> str: Input should be a valid string;
body -> messages -> 1 -> content -> list[...] -> 0: Input tag 'thinking' found using 'type' does not match any of the expected tags: 'text', 'image', 'tool_use', 'tool_result'
```

**Fix**: Added `ThinkingBlock` and `RedactedThinkingBlock` to the list of accepted request content blocks.

### OpenAI API: Use more common thinking tag format

Thinking blocks were formatted as `<thinking signature="Eok...">`, which I'm not sure there's any client that can handle.

**Fix**: Changed to the common `<think>` tag format.

### OpenAI API: Fix streaming reasoning chunks

When streaming reasoning content, each chunk was being enclosed in its own thinking tag, resulting in broken output:

`<thinking>User</thinking><thinking> wants to simpl</thinking><thinking>ify -</thinking>...`

**Fix**: Moved the enclosing tag logic into the start and stop event handlers so the tags wrap the entire thinking content rather than each chunk.