### PR TITLE
fix(claude_api): stop leaking CLI-detected anthropic-beta into client requests

### DIFF
--- a/ccproxy/plugins/claude_api/adapter.py
+++ b/ccproxy/plugins/claude_api/adapter.py
@@ -88,9 +88,9 @@ class ClaudeAPIAdapter(BaseHTTPAdapter):
 
         # Minimal beta tags required for OAuth-based Claude Code auth
         filtered_headers["anthropic-version"] = "2023-06-01"
-        filtered_headers["anthropic-beta"] = self._merge_anthropic_beta(
-            headers.get("anthropic-beta") or headers.get("Anthropic-Beta")
-        )
+        client_beta = headers.get("anthropic-beta") or headers.get("Anthropic-Beta")
+        filtered_headers["anthropic-beta"] = self._merge_anthropic_beta(client_beta)
+        client_provided_beta = bool(client_beta)
 
         # Add CLI headers if available, but never allow overriding auth
         cli_headers = self._collect_cli_headers()
@@ -106,6 +106,14 @@ class ClaudeAPIAdapter(BaseHTTPAdapter):
                     )
                     continue
                 if lk == "anthropic-beta":
+                    # Client is authoritative for its own beta features.
+                    # Only fall back to CLI-detected betas when the client
+                    # sent none — otherwise CLI defaults like
+                    # context-1m-2025-08-07 leak into client requests that
+                    # never asked for them and break model/account combos
+                    # that don't support those betas.
+                    if client_provided_beta:
+                        continue
                     filtered_headers[lk] = self._merge_anthropic_beta(
                         value, base=filtered_headers.get("anthropic-beta")
                     )

--- a/tests/plugins/claude_api/unit/test_adapter.py
+++ b/tests/plugins/claude_api/unit/test_adapter.py
@@ -140,13 +140,13 @@ class TestClaudeAPIAdapter:
         assert "custom-tag" in beta_tags
 
     @pytest.mark.asyncio
-    async def test_prepare_provider_request_merges_cli_detected_beta(
+    async def test_prepare_provider_request_cli_beta_used_when_client_omits_header(
         self,
         mock_detection_service: ClaudeAPIDetectionService,
         mock_auth_manager: Mock,
         mock_http_pool_manager: Mock,
     ) -> None:
-        """CLI-detected beta tags from detection cache must flow through to upstream request."""
+        """CLI-detected beta tags are used as a fallback when the client sends no anthropic-beta."""
         mock_detection_service.get_detected_headers = Mock(  # type: ignore[method-assign]
             return_value=DetectedHeaders(
                 {
@@ -170,10 +170,7 @@ class TestClaudeAPIAdapter:
                 "max_tokens": 100,
             }
         ).encode()
-        headers = {
-            "content-type": "application/json",
-            "anthropic-beta": "client-only-tag",
-        }
+        headers = {"content-type": "application/json"}
 
         _, result_headers = await adapter.prepare_provider_request(
             body, headers, "/v1/messages"
@@ -184,7 +181,60 @@ class TestClaudeAPIAdapter:
         assert "oauth-2025-04-20" in beta_tags
         assert "context-1m-2025-08-07" in beta_tags
         assert "interleaved-thinking-2025-05-14" in beta_tags
-        assert "client-only-tag" in beta_tags
+
+    @pytest.mark.asyncio
+    async def test_prepare_provider_request_cli_beta_skipped_when_client_sends_header(
+        self,
+        mock_detection_service: ClaudeAPIDetectionService,
+        mock_auth_manager: Mock,
+        mock_http_pool_manager: Mock,
+    ) -> None:
+        """When the client sends its own anthropic-beta the CLI-detected betas must not leak in.
+
+        Otherwise CLI defaults like ``context-1m-2025-08-07`` get injected into
+        every request and break model/account combos that don't support them
+        (e.g. haiku, or accounts without the long-context beta).
+        """
+        mock_detection_service.get_detected_headers = Mock(  # type: ignore[method-assign]
+            return_value=DetectedHeaders(
+                {
+                    "anthropic-beta": "claude-code-20250219,context-1m-2025-08-07,advisor-tool-2026-03-01",
+                }
+            )
+        )
+        from ccproxy.plugins.claude_api.config import ClaudeAPISettings
+
+        adapter = ClaudeAPIAdapter(
+            detection_service=mock_detection_service,
+            config=ClaudeAPISettings(),
+            auth_manager=mock_auth_manager,
+            http_pool_manager=mock_http_pool_manager,
+        )
+
+        body = json.dumps(
+            {
+                "model": "claude-haiku-4-5-20251001",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 100,
+            }
+        ).encode()
+        headers = {
+            "content-type": "application/json",
+            "anthropic-beta": "oauth-2025-04-20,prompt-caching-scope-2026-01-05",
+        }
+
+        _, result_headers = await adapter.prepare_provider_request(
+            body, headers, "/v1/messages"
+        )
+
+        beta_tags = set(result_headers["anthropic-beta"].split(","))
+        # Required OAuth tags + the client's own tags are present.
+        assert "claude-code-20250219" in beta_tags
+        assert "oauth-2025-04-20" in beta_tags
+        assert "prompt-caching-scope-2026-01-05" in beta_tags
+        # CLI-detected betas the client did not request must NOT leak in.
+        assert "context-1m-2025-08-07" not in beta_tags
+        assert "advisor-tool-2026-03-01" not in beta_tags
 
     def test_merge_anthropic_beta_helper(self) -> None:
         """_merge_anthropic_beta deduplicates and always includes required tags."""


### PR DESCRIPTION
## Summary

When Claude Code CLI (or any external client) sends its own \`anthropic-beta\` header to the \`/claude\` endpoint, ccproxy was still merging in beta tags it had captured from the **local** \`claude\` CLI's own outbound requests during startup detection. Those CLI defaults — currently \`context-1m-2025-08-07\`, \`advisor-tool-2026-03-01\`, \`effort-2025-11-24\`, etc. — then ended up on **every** proxied request, including ones targeting models or accounts that don't support those betas.

Concretely, running:

\`\`\`bash
ANTHROPIC_BASE_URL=http://127.0.0.1:8000/claude claude
\`\`\`

…and triggering any small request against \`claude-haiku-4-5-20251001\` produced:

\`\`\`json
{
  \"type\": \"error\",
  \"error\": {
    \"type\": \"invalid_request_error\",
    \"message\": \"The long context beta is not yet available for this subscription.\"
  }
}
\`\`\`

…because haiku does not support the 1M-context beta at all, even on accounts that do have long-context access for Sonnet. The client never asked for \`context-1m-2025-08-07\` — ccproxy injected it.

## Root cause

\`ccproxy/plugins/claude_api/adapter.py\` (line ~91 onward) does the merge in two stages:

1. First, merge required OAuth tags into the **client's** \`anthropic-beta\` — correct.
2. Then, iterate CLI-detected headers from the detection cache and merge their \`anthropic-beta\` **on top** via \`_merge_anthropic_beta(value, base=...)\` — wrong when the client already provided its own beta.

PR #54/#56 (\"merge client anthropic-beta tags with required OAuth tags\") fixed step 1, but step 2 was a separate path that pre-dated it and kept smashing CLI-default betas into authoritative client requests. There was even a test asserting this broken behavior.

## Fix

The client is authoritative for its own beta features. The CLI-detected \`anthropic-beta\` is now only used as a **fallback** when the client did not send one of its own. When the client provides any \`anthropic-beta\`, the outgoing request gets exactly:

\`\`\`
client tags + claude-code-20250219 + oauth-2025-04-20
\`\`\`

…and nothing else. Other CLI-detected headers (non-beta) still flow through unchanged.

## Test plan

- [x] Replaced \`test_prepare_provider_request_merges_cli_detected_beta\` (which asserted the broken behavior) with two tests reflecting the new contract:
  - \`..._cli_beta_used_when_client_omits_header\` — fallback path: when the client sends no \`anthropic-beta\`, CLI-detected betas including \`context-1m-2025-08-07\` and \`interleaved-thinking-2025-05-14\` flow through.
  - \`..._cli_beta_skipped_when_client_sends_header\` — primary path: when the client sends its own \`anthropic-beta\`, CLI-only tags (\`context-1m-2025-08-07\`, \`advisor-tool-2026-03-01\`) are explicitly asserted **not** to leak in, while the client's tags + required OAuth tags do.
- [x] \`uv run pytest tests/plugins/claude_api/unit/test_adapter.py -x -q\` — 19 passed.
- [x] \`uv run ruff check\` / \`uv run ruff format\` / \`uv run mypy ccproxy/plugins/claude_api/adapter.py\` — clean.
- [x] \`make pre-commit\` (via the commit hook) — passed.

After this lands, \`ANTHROPIC_BASE_URL=http://127.0.0.1:8000/claude claude\` will stop hitting the long-context 400 on haiku requests, and accounts with mixed model access (Sonnet 1M + Haiku) will work correctly.