### PR TITLE
fix(formatters): strip billing header from chat converter system content

### DIFF
--- a/ccproxy/llms/formatters/anthropic_to_openai/requests.py
+++ b/ccproxy/llms/formatters/anthropic_to_openai/requests.py
@@ -285,9 +285,14 @@ def convert__anthropic_message_to_openai_chat__request(
     # System prompt
     if request.system:
         if isinstance(request.system, str):
-            sys_content = request.system
+            sys_content = _strip_nonsemantic_system_lines(request.system)
         else:
-            sys_content = "".join(block.text for block in request.system)
+            cleaned_blocks = (
+                _strip_nonsemantic_system_lines(block.text or "")
+                for block in request.system
+                if block.text
+            )
+            sys_content = "".join(b for b in cleaned_blocks if b)
         if sys_content:
             openai_messages.append({"role": "system", "content": sys_content})
 

--- a/tests/unit/llms/formatters/test_anthropic_to_openai_helpers.py
+++ b/tests/unit/llms/formatters/test_anthropic_to_openai_helpers.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from ccproxy.llms.formatters.anthropic_to_openai import (
+    convert__anthropic_message_to_openai_chat__request,
     convert__anthropic_message_to_openai_chat__response,
     convert__anthropic_message_to_openai_responses__request,
     convert__anthropic_message_to_openai_responses__stream,
@@ -709,3 +710,116 @@ def test_instructions_stable_across_requests_with_different_cch() -> None:
     out2 = convert__anthropic_message_to_openai_responses__request(make_req("bbb222"))
 
     assert out1.instructions == out2.instructions == base_system
+
+
+def _chat_system_content(out: openai_models.ChatCompletionRequest) -> str | None:
+    for msg in out.messages:
+        role = getattr(msg, "role", None) or (
+            msg.get("role") if isinstance(msg, dict) else None
+        )
+        if role == "system":
+            content = getattr(msg, "content", None)
+            if content is None and isinstance(msg, dict):
+                content = msg.get("content")
+            return content if isinstance(content, str) else None
+    return None
+
+
+def test_chat_billing_header_stripped_from_string_system() -> None:
+    """x-anthropic-billing-header lines must not appear in chat system content."""
+    req = anthropic_models.CreateMessageRequest(
+        model="claude-3",
+        system=(
+            "x-anthropic-billing-header: cc_version=2.1.117.48f; cc_entrypoint=cli; cch=71fea;\n"
+            "You are a helpful assistant."
+        ),
+        messages=[anthropic_models.Message(role="user", content="Hi")],
+        max_tokens=128,
+    )
+
+    out = convert__anthropic_message_to_openai_chat__request(req)
+    assert _chat_system_content(out) == "You are a helpful assistant."
+
+
+def test_chat_billing_header_stripped_from_block_system() -> None:
+    """Billing header lines in chat system *blocks* must not appear in system content."""
+    req = anthropic_models.CreateMessageRequest(
+        model="claude-3",
+        system=[
+            anthropic_models.TextBlock(
+                type="text",
+                text=(
+                    "x-anthropic-billing-header: cc_version=2.1.117.48f; cch=deadbeef;\n"
+                    "You are a helpful assistant."
+                ),
+            ),
+            anthropic_models.TextBlock(
+                type="text",
+                text="Additional context.",
+            ),
+        ],
+        messages=[anthropic_models.Message(role="user", content="Hi")],
+        max_tokens=128,
+    )
+
+    out = convert__anthropic_message_to_openai_chat__request(req)
+    sys_content = _chat_system_content(out)
+    assert sys_content is not None
+    assert "x-anthropic-billing-header" not in sys_content
+    assert "You are a helpful assistant." in sys_content
+    assert "Additional context." in sys_content
+
+
+def test_chat_billing_header_only_system_drops_system_message() -> None:
+    """A system consisting solely of billing header lines yields no system message."""
+    req = anthropic_models.CreateMessageRequest(
+        model="claude-3",
+        system="x-anthropic-billing-header: cc_version=2.1; cch=abc123;",
+        messages=[anthropic_models.Message(role="user", content="Hi")],
+        max_tokens=128,
+    )
+
+    out = convert__anthropic_message_to_openai_chat__request(req)
+    roles = [
+        getattr(msg, "role", None)
+        or (msg.get("role") if isinstance(msg, dict) else None)
+        for msg in out.messages
+    ]
+    assert "system" not in roles
+
+
+def test_chat_billing_header_stripped_case_insensitive() -> None:
+    """Stripping must be case-insensitive for the chat system content."""
+    req = anthropic_models.CreateMessageRequest(
+        model="claude-3",
+        system=(
+            "X-Anthropic-Billing-Header: cc_version=2.1; cch=abc123;\n"
+            "Real instructions."
+        ),
+        messages=[anthropic_models.Message(role="user", content="Hi")],
+        max_tokens=128,
+    )
+
+    out = convert__anthropic_message_to_openai_chat__request(req)
+    assert _chat_system_content(out) == "Real instructions."
+
+
+def test_chat_system_stable_across_requests_with_different_cch() -> None:
+    """Two chat requests differing only in cch= hash must produce identical system content."""
+    base_system = "You are a helpful assistant."
+
+    def make_req(cch_hash: str) -> anthropic_models.CreateMessageRequest:
+        return anthropic_models.CreateMessageRequest(
+            model="claude-3",
+            system=(
+                f"x-anthropic-billing-header: cc_version=2.1.117; cch={cch_hash};\n"
+                + base_system
+            ),
+            messages=[anthropic_models.Message(role="user", content="Hi")],
+            max_tokens=128,
+        )
+
+    out1 = convert__anthropic_message_to_openai_chat__request(make_req("aaa111"))
+    out2 = convert__anthropic_message_to_openai_chat__request(make_req("bbb222"))
+
+    assert _chat_system_content(out1) == _chat_system_content(out2) == base_system


### PR DESCRIPTION
## Summary

Follow-up to #62 addressing [this Copilot review comment](https://github.com/CaddyGlow/ccproxy-api/pull/62#discussion_r3177085223): `_strip_nonsemantic_system_lines()` was only applied to the Responses API path. `convert__anthropic_message_to_openai_chat__request()` still forwarded `request.system` verbatim, so Anthropic->OpenAI Chat requests continued to carry the per-request unique `x-anthropic-billing-header: ...; cch=<hash>;` prefix and could still defeat caching/prompt stability for the chat-completions endpoint.

## Changes

### `ccproxy/llms/formatters/anthropic_to_openai/requests.py`

Apply `_strip_nonsemantic_system_lines()` to both the `str` and `list[TextBlock]` system paths in the chat converter, mirroring the Responses-API path. If the cleaned content is empty, the system message is dropped entirely instead of injecting an empty `system` role.

```python
# Before: billing header forwarded verbatim into chat system content
sys_content = "".join(block.text for block in request.system)

# After: header stripped per-block
cleaned_blocks = (
    _strip_nonsemantic_system_lines(block.text or "")
    for block in request.system if block.text
)
sys_content = "".join(b for b in cleaned_blocks if b)
```

### Tests

Added 5 chat-converter tests in `tests/unit/llms/formatters/test_anthropic_to_openai_helpers.py` mirroring the Responses-API coverage:

- `test_chat_billing_header_stripped_from_string_system`
- `test_chat_billing_header_stripped_from_block_system`
- `test_chat_billing_header_only_system_drops_system_message`
- `test_chat_billing_header_stripped_case_insensitive`
- `test_chat_system_stable_across_requests_with_different_cch`

## Test plan

- [x] `uv run pytest tests/unit/llms/formatters/test_anthropic_to_openai_helpers.py` -- 21 passed
- [x] `uv run mypy ccproxy/llms/formatters/anthropic_to_openai/requests.py` -- clean
- [x] `uv run ruff check` / `uv run ruff format --check` -- clean
- [x] pre-commit hooks passed on commit