### PR TITLE
fix(copilot): add missing custom_path param to save_credentials

### DIFF
--- a/ccproxy/plugins/copilot/oauth/provider.py
+++ b/ccproxy/plugins/copilot/oauth/provider.py
@@ -473,11 +473,18 @@ class CopilotOAuthProvider(ProfileLoggingMixin):
             )
             return None
 
-    async def save_credentials(self, credentials: CopilotCredentials | None) -> bool:
+    async def save_credentials(
+        self,
+        credentials: CopilotCredentials | None,
+        custom_path: Any | None = None,
+    ) -> bool:
         """Save credentials to storage.
 
         Args:
             credentials: Copilot credentials to save (None to clear)
+            custom_path: Optional custom storage path (accepted for interface
+                compatibility with other providers but unused — Copilot
+                credentials are always written to the provider's own storage).
 
         Returns:
             True if save was successful


### PR DESCRIPTION
Fixes #67

## Problem

`DeviceCodeFlow.run()` (and other OAuth flows) call `provider.save_credentials(credentials, save_path)` with two arguments. `ClaudeOAuthProvider` and `CodexOAuthProvider` both accept `custom_path: Any | None = None`, but `CopilotOAuthProvider.save_credentials()` only accepted one positional argument, causing:

```
TypeError: CopilotOAuthProvider.save_credentials() takes 2 positional arguments but 3 were given
```

This broke `ccproxy auth login copilot` entirely on v0.2.10.

## Fix

Add `custom_path: Any | None = None` to `CopilotOAuthProvider.save_credentials()` for interface compatibility. The Copilot provider ignores the value (it always writes to its own storage) — this is purely a signature alignment fix.

## How it was introduced

Commit `9e44f249` added `--file` / custom save-path support to the OAuth flows and updated the Claude and Codex providers but missed the Copilot provider.