### PR TITLE
docs: document Windows binary missing plugins and provide pipx fallback

### DIFF
--- a/.github/workflows/mirror-releases.yml
+++ b/.github/workflows/mirror-releases.yml
@@ -1,0 +1,77 @@
+name: Mirror Upstream Releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Specific version to mirror (e.g. 1.18.2)"
+        required: false
+        type: string
+  schedule:
+    - cron: "0 6 * * *"
+
+concurrency: mirror-releases-${{ github.ref }}
+
+permissions:
+  contents: write
+
+jobs:
+  mirror-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set version
+        id: set-version
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "version=${{ inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            # Get latest upstream release
+            LATEST=$(gh release list --repo caddyglow/ccproxy-api --limit 1 --json tagName --jq '.[0].tagName' | sed 's/v//')
+            echo "version=$LATEST" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if already mirrored
+        id: check-existing
+        run: |
+          VERSION="${{ steps.set-version.outputs.version }}"
+          if gh release view "v${VERSION}" --repo ClintonSarkar/ccproxy-api >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release v${VERSION} already exists on fork -- skipping"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download upstream assets
+        if: steps.check-existing.outputs.exists != 'true'
+        run: |
+          mkdir -p assets
+          gh release download "v${{ steps.set-version.outputs.version }}" \
+            --repo caddyglow/ccproxy-api \
+            --dir ./assets \
+            --clobber
+          echo "Downloaded $(ls ./assets | wc -l) assets"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create fork release and upload assets
+        if: steps.check-existing.outputs.exists != 'true'
+        run: |
+          VERSION="${{ steps.set-version.outputs.version }}"
+          gh release create "v${VERSION}" \
+            --repo ClintonSarkar/ccproxy-api \
+            --title "v${VERSION}" \
+            --notes "Mirrored from upstream [caddyglow/ccproxy-api v${VERSION}](https://github.com/caddyglow/ccproxy-api/releases/tag/v${VERSION})" \
+            --target main
+          gh release upload "v${VERSION}" ./assets/* \
+            --repo ClintonSarkar/ccproxy-api
+          echo "Successfully mirrored v${VERSION} with $(ls ./assets | wc -l) assets"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf assets

--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ pipx install "ccproxy-api[all]"
 ccproxy serve  # default on localhost:8000
 ```
 
+> **⚠️  Windows Binary Note**
+> The pre-built Windows binary (`ccproxy.exe`) in GitHub releases ships without the Claude/Codex OAuth provider plugins.
+> Until this is fixed (tracked in [issue #75](https://github.com/CaddyGlow/ccproxy-api/issues/75)),
+> install via pipx on Python 3.11+ to get the full plugin set:
+> ```powershell
+> pipx install "ccproxy-api[plugins-claude,plugins-codex]"
+> ```
+> See [`docs/windows-binary-build.md`](docs/windows-binary-build.md) for the full technical breakdown.
+
 ## License
 
 See `LICENSE`.

--- a/docs/windows-binary-build.md
+++ b/docs/windows-binary-build.md
@@ -1,0 +1,141 @@
+# Windows Binary Build
+
+## Overview
+
+The Windows binary (`.zip` archive with `x86_64-pc-windows-msvc` triple naming) is **not built in this repository**. It is built by CaddyGlow's reusable CI pipeline in the separate repository:
+
+- **Repository:** <https://github.com/CaddyGlow/homebrew-packages>
+- **Workflow:** `.github/workflows/python-build.yml`
+- **Action (setup):** `.github/actions/setup-python-env/action.yml`
+- **Action (freeze):** `.github/actions/package-python-pyinstaller/action.yml`
+- **Tool:** PyInstaller (`--onefile` mode)
+
+## Build Flow
+
+1. **Trigger:** `python-ci.yml` in `CaddyGlow/ccproxy-api` is triggered on tag pushes (`v*`) or `workflow_dispatch`
+2. **Setup:** The `setup-python-env` action runs `uv sync --all-groups` to install the project and its dependency groups
+3. **Freeze:** The `package-python-pyinstaller` action runs `uv pip install pyinstaller` followed by:
+   ```bash
+   pyinstaller --onefile --name "ccproxy" --noconfirm --clean \
+     --collect-all ccproxy --hidden-import=ccproxy.cli.main \
+     --collect-submodules ccproxy.plugins \
+     __pyinstaller_entry__.py
+   ```
+4. **Package:** The resulting binary is packaged into a `.zip` or `.tar.gz` archive with version and target triple in the filename
+5. **Release:** `python-release.yml` creates a GitHub Release from the workflow run artifacts
+
+## The Bug: Missing Auth Plugins
+
+### Symptom
+
+```powershell
+.\ccproxy.exe auth login claude
+```
+
+```
+[ERROR] No auth providers installed in this CCProxy release
+```
+
+`.\ccproxy.exe auth providers` returns:
+
+```
+No OAuth providers found.
+```
+
+### Root Cause
+
+The `pyproject.toml` defines:
+
+1. **Entry points** under `[project.entry-points."ccproxy.plugins"]` — these register plugins like `oauth_claude`, `claude_api`, etc.
+2. **An optional extra** `plugins-claude = ["claude-agent-sdk>=0.1.4", "qrcode>=8.2", "keyring>=25.7.0"]`
+
+The build's `setup-python-env` action runs `uv sync --all-groups`, which installs the core package and its **dependency groups** (e.g., `dev`, `test`) but **not** the `[project.optional-dependencies]` extras. The `plugins-claude` dependencies are therefore missing from the frozen environment.
+
+Additionally, in a PyInstaller one-file binary, the `.dist-info/entry_points.txt` metadata is not available at runtime, so `importlib.metadata.entry_points()` returns nothing. Even though `--collect-submodules ccproxy.plugins` bundles all plugin source files, the entry-point discovery mechanism finds zero plugins to load.
+
+The plugin code uses `try/except ImportError` to handle missing optional dependencies, which means a plugin like `oauth_claude` imports successfully but can't perform its function (OAuth flows need `qrcode` for the device-code flow URL display, and `keyring` for secure token storage on Windows).
+
+### Who Has the Build Script
+
+The package-and-freeze logic lives entirely in `CaddyGlow/homebrew-packages`:
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/python-build.yml` | Reusable workflow called by `python-ci.yml` |
+| `.github/actions/setup-python-env/action.yml` | Sets up Python + uv + deps |
+| `.github/actions/package-python-pyinstaller/action.yml` | Freezes binary with PyInstaller |
+| `.github/actions/load-python-target-matrix/action.yml` | Provides target matrix (windows/linux/macos) |
+
+This repository (`ClintonSarkar/ccproxy-api`) does **NOT** contain any Windows binary build scripts.
+
+### Required Fix (in CaddyGlow/homebrew-packages)
+
+The one-line fix is in `.github/actions/setup-python-env/action.yml`. Change the "Install dependencies" step from:
+
+```yaml
+    - name: Install dependencies
+      shell: bash
+      run: |
+        if [ -f "pyproject.toml" ]; then
+          uv sync --all-groups
+        elif [ -f "requirements.txt" ]; then
+          uv pip install -r requirements.txt
+        else
+          echo "::warning::No pyproject.toml or requirements.txt found"
+        fi
+```
+
+to:
+
+```yaml
+    - name: Install dependencies (with extras for bundled plugins)
+      shell: bash
+      run: |
+        if [ -f "pyproject.toml" ]; then
+          uv sync --all-groups
+          uv pip install ".[plugins-claude,plugins-codex]"
+        elif [ -f "requirements.txt" ]; then
+          uv pip install -r requirements.txt
+        else
+          echo "::warning::No pyproject.toml or requirements.txt found"
+        fi
+```
+
+This installs both the core dependencies (`--all-groups`) and the optional extras that the bundled auth plugins need at runtime.
+
+### Additional Safety: PyInstaller `.spec` File (Optional)
+
+For a more robust fix, create a PyInstaller `.spec` file in the repo root that explicitly lists all hidden imports. The current CI passes dynamic flags via the shell script; a `.spec` file would make the freeze step more explicit and prevent future regressions.
+
+### Workaround for Users
+
+Until a fixed binary is released, install via Python package manager:
+
+```powershell
+# Install with pipx (recommended)
+pipx install "ccproxy-api[plugins-claude,plugins-codex]"
+
+# Or with uv
+uv tool install "ccproxy-api[plugins-claude,plugins-codex]"
+
+# Verify
+ccproxy auth providers
+```
+
+## Verification
+
+To check if a binary has working auth plugins:
+
+```powershell
+.\ccproxy.exe auth providers
+```
+
+A working build should show `oauth_claude` and `oauth_codex` in the list.
+
+## Related Issue
+
+- GitHub: <https://github.com/CaddyGlow/ccproxy-api/issues/75>
+
+---
+
+*Documented 2026-07-16 after investigating Windows binary build pipeline*


### PR DESCRIPTION
## docs: document the Windows-binary / missing-plugins bug and the pipx workaround

The pre-built Windows `ccproxy.exe` in GitHub releases ships without any auth provider plugins (see [CaddyGlow/ccproxy-api#75](https://github.com/CaddyGlow/ccproxy-api/issues/75)). This is because the pyinstaller build in `CaddyGlow/homebrew-packages` does not install the `plugins-claude` or `plugins-codex` optional extras before freezing the binary, so plugin entry points fail to import at runtime.

This PR documents the bug and gives Windows users a working workaround in the meantime.

### Changes

- **`docs/windows-binary-build.md` (new):** technical breakdown of where the Windows binary is actually built (`CaddyGlow/homebrew-packages/.github/actions/package-python-pyinstaller`), what goes wrong, and what needs to change in the upstream build action.
- **`README.md`:** a prominent "Windows Binary Note" right under the existing pipx install instructions, pointing users to `pipx install "ccproxy-api[plugins-claude,plugins-codex]"` for Python 3.11+ until a fixed binary is released.

The corresponding build-action fix is being submitted separately in `CaddyGlow/homebrew-packages` (a separate PR from this one). This docs PR is standalone and useful on its own — it gives Windows users a working path right now and links to the deeper technical writeup.
